### PR TITLE
Use Lavarel url() function

### DIFF
--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -93,17 +93,14 @@ class Breadcrumbs {
 
     public static function automatic()
     {
-        $url = \Request::path();
-        $urlExplode = explode('/', $url);
 
-        $url = "/";
+        $parts = \Request::segments();
 
-        foreach ($urlExplode as $segment) {
-            $url .= $segment."/";
+        foreach ($parts as $part) {
 
-            $title = str_replace("-", " ", $segment);
+            $title = str_replace("-", " ", $part);
 
-            self::addBreadcrumb($title, $url);
+            self::addBreadcrumb($title, url($part));
         }
 
         return self::generate();
@@ -112,7 +109,7 @@ class Breadcrumbs {
     private static function isFirstBreadcrumb()
     {
         if (isset(self::$_config['automaticFirstCrumb']) && self::$_config['automaticFirstCrumb']['enabled'] === true) {
-            self::prepend( self::createBreadcrumb(self::$_config['automaticFirstCrumb']['value'], '/') );
+            self::prepend( self::createBreadcrumb(self::$_config['automaticFirstCrumb']['value'], url('/')) );
         }
     }
 }


### PR DESCRIPTION
For automatic crumbs, and the first one, it's better to use the built in Lavarel function `url()`. This adds support for having Lavarel in a sub directory. This way, the Home link will point to that subdirectory instead of the root.

This also fixes issue #1 .
