### PR TITLE
Support for deep breadcrumbs

### DIFF
--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -95,12 +95,14 @@ class Breadcrumbs {
     {
 
         $parts = \Request::segments();
+		$current = "";
 
         foreach ($parts as $part) {
 
             $title = str_replace("-", " ", $part);
+			$current .= "/" . $part;
 
-            self::addBreadcrumb($title, url($part));
+            self::addBreadcrumb($title, url($current));
         }
 
         return self::generate();


### PR DESCRIPTION
It seems I did not commit all changes in the previous pull request. 

This commit fixes deep links (with multiple parts, e.g. /users/name/comments/all)
