### PR TITLE
Add PSR-4 autoload and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,20 +11,6 @@ Edit your .json file and add the following line to your "require"
 After this run the `composer update` to update your framework and get the breadcrumb class loaded into your files.
 The files will be placed in the `vendor/mjanssen/laravel-5-breadcrumbs` folder.
 
-After the files will be downloaded and stored in your Vendor folder, the class needs to be autoloaded by Composer.
-To do this, edit your own composer.json file to match it like this:
-
-```
-"psr-4": {
-  "App\\": "app/",
-    "mjanssen\\BreadcrumbsBundle\\": "vendor/mjanssen/laravel-5-breadcrumbs/src"
-  }
-```
-
-After you updated the composer.json reload the composer autoload file.
-
-``composer dump-autoload``
-
 The class can now be used within the framework. Make sure you **use** it in *controllers* for example.
 
 ``use mjanssen\BreadcrumbsBundle\Breadcrumbs;``

--- a/composer.json
+++ b/composer.json
@@ -9,5 +9,10 @@
         }
     ],
     "minimum-stability": "dev",
-    "require": {}
+    "require": {},
+    "autoload": {
+        "psr-4": {
+            "mjanssen\\BreadcrumbsBundle\\": "src"
+        }
+    }
 }


### PR DESCRIPTION
I've added the PSR-4 autoload to the composer.json file so that there is no longer a need to manually autoload this for each app the package is installed on. I've also updated the readme to remove the redundant installation instructions.